### PR TITLE
[MI-2326] Added the handling of multiple clusters for websocket events

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -4,7 +4,7 @@
     "description": "This plugin provides presence information to Outlook client application.",
     "support_url": "https://github.com/Brightscout/mattermost-plugin-outlook-presence/issues",
     "release_notes_url": "https://github.com/Brightscout/mattermost-plugin-outlook-presence/releases",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "min_server_version": "5.37.0",
     "server": {
         "executables": {

--- a/server/api.go
+++ b/server/api.go
@@ -79,11 +79,14 @@ func (p *Plugin) PublishStatusChanged(w http.ResponseWriter, r *http.Request) {
 	}
 
 	statusChangedEvent.Email = user.Email
+
+	// Broadcasting the event here only works for the current cluster, so to broadcast it for other clusters,
+	// we are publishing a cluster event and that event will be handled by all the other clusters (not the current cluster)
 	p.BroadcastEvent(statusChangedEvent)
 
 	eventBytes, marshalErr := json.Marshal(statusChangedEvent)
 	if marshalErr != nil {
-		p.API.LogDebug("Error in marshaling the status changed event", "Error", marshalErr.Error())
+		p.API.LogDebug("Error in marshaling the \"status changed\" event", "Error", marshalErr.Error())
 		writeStatusOK(w)
 		return
 	}

--- a/server/api.go
+++ b/server/api.go
@@ -47,7 +47,7 @@ func (p *Plugin) handleAuthRequired(handleFunc func(w http.ResponseWriter, r *ht
 func (p *Plugin) serveWebSocket(w http.ResponseWriter, r *http.Request) {
 	connection, err := websocket.CreateConnection(w, r)
 	if err != nil {
-		p.writeError(w, fmt.Sprintf("error in creating websocket connection. Error: %s", err.Error()), http.StatusInternalServerError)
+		p.writeError(w, fmt.Sprintf("Error in creating websocket connection. Error: %s", err.Error()), http.StatusInternalServerError)
 		return
 	}
 
@@ -63,7 +63,7 @@ func (p *Plugin) serveWebSocket(w http.ResponseWriter, r *http.Request) {
 func (p *Plugin) PublishStatusChanged(w http.ResponseWriter, r *http.Request) {
 	statusChangedEvent, err := serializer.UserStatusFromJSON(r.Body)
 	if err != nil {
-		p.writeError(w, fmt.Sprintf("error in deserializing the request body. Error: %s", err.Error()), http.StatusBadRequest)
+		p.writeError(w, fmt.Sprintf("Error in deserializing the request body. Error: %s", err.Error()), http.StatusBadRequest)
 		return
 	}
 
@@ -92,7 +92,7 @@ func (p *Plugin) PublishStatusChanged(w http.ResponseWriter, r *http.Request) {
 		Id:   constants.ClusterEvent,
 		Data: eventBytes,
 	}, model.PluginClusterEventSendOptions{SendType: model.PluginClusterEventSendTypeReliable}); err != nil {
-		p.API.LogDebug("Error in publishing event to clusters", "Error", err.Error())
+		p.API.LogDebug("Error in publishing the event to clusters", "Error", err.Error())
 	}
 
 	writeStatusOK(w)
@@ -125,7 +125,7 @@ func (p *Plugin) GetStatusesForAllUsers(w http.ResponseWriter, r *http.Request) 
 
 	statusArr, statusErr := p.API.GetUserStatusesByIds(userIds)
 	if statusErr != nil {
-		p.writeError(w, fmt.Sprintf("error in getting statuses. Error: %s", statusErr.Error()), statusErr.StatusCode)
+		p.writeError(w, fmt.Sprintf("Error in getting statuses. Error: %s", statusErr.Error()), statusErr.StatusCode)
 		return
 	}
 

--- a/server/constants/constants.go
+++ b/server/constants/constants.go
@@ -1,6 +1,7 @@
 package constants
 
 const (
-	Page        = "page"
-	DefaultPage = 0
+	Page         = "page"
+	DefaultPage  = 0
+	ClusterEvent = "outlook_presence_status_changed_cluster_event"
 )

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -44,6 +44,7 @@ func (p *Plugin) OnPluginClusterEvent(c *plugin.Context, ev model.PluginClusterE
 		return
 	}
 
+	// Broadcast the event for all the clusters
 	p.BroadcastEvent(event)
 }
 

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -1,11 +1,15 @@
 package main
 
 import (
+	"encoding/json"
 	"net/http"
 	"sync"
 
+	"github.com/Brightscout/mattermost-plugin-outlook-presence/server/constants"
+	"github.com/Brightscout/mattermost-plugin-outlook-presence/server/serializer"
 	"github.com/Brightscout/mattermost-plugin-outlook-presence/server/websocket"
 	"github.com/gorilla/mux"
+	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/mattermost/mattermost-server/v6/plugin"
 )
 
@@ -29,4 +33,24 @@ func (p *Plugin) ServeHTTP(c *plugin.Context, w http.ResponseWriter, r *http.Req
 	p.router.ServeHTTP(w, r)
 }
 
-// See https://developers.mattermost.com/extend/plugins/server/reference/
+func (p *Plugin) OnPluginClusterEvent(c *plugin.Context, ev model.PluginClusterEvent) {
+	if ev.Id != constants.ClusterEvent {
+		return
+	}
+
+	var event *serializer.UserStatus
+	if err := json.Unmarshal(ev.Data, &event); err != nil {
+		p.API.LogDebug("Error in unmarshaling the cluster event data", "Error", err.Error())
+		return
+	}
+
+	p.BroadcastEvent(event)
+}
+
+func (p *Plugin) RegisterClient(client *websocket.Client) {
+	p.wsPool.Register <- client
+}
+
+func (p *Plugin) BroadcastEvent(event *serializer.UserStatus) {
+	p.wsPool.Broadcast <- event
+}

--- a/server/websocket/client.go
+++ b/server/websocket/client.go
@@ -19,7 +19,7 @@ func (c *Client) Read(api plugin.API) {
 	for {
 		_, content, err := c.Conn.ReadMessage()
 		if err != nil {
-			api.LogError("error in reading the message received through the websocket.", "Error", err.Error())
+			api.LogDebug("error in reading the message received through the websocket.", "Error", err.Error())
 			return
 		}
 

--- a/server/websocket/client.go
+++ b/server/websocket/client.go
@@ -19,10 +19,10 @@ func (c *Client) Read(api plugin.API) {
 	for {
 		_, content, err := c.Conn.ReadMessage()
 		if err != nil {
-			api.LogDebug("error in reading the message received through the websocket.", "Error", err.Error())
+			api.LogDebug("Error in reading the message received through the websocket.", "Error", err.Error())
 			return
 		}
 
-		api.LogInfo("message received through the websocket.", "Message", string(content))
+		api.LogInfo("Message received through the websocket.", "Message", string(content))
 	}
 }

--- a/server/websocket/pool.go
+++ b/server/websocket/pool.go
@@ -40,7 +40,7 @@ func (p *Pool) Start(api plugin.API) {
 			api.LogInfo("Sending message to all clients in pool")
 			for client := range p.Clients {
 				if err := client.Conn.WriteJSON(statusChangedEvent); err != nil {
-					api.LogError("error in broadcasting the status changed event.", "Error", err.Error())
+					api.LogError("Error in broadcasting the status changed event.", "Error", err.Error())
 				}
 			}
 		}


### PR DESCRIPTION
Created a constant for the cluster event to be published
Created some functions for registering a client and broadcasting an event
Added a hook for handling the cluster event and broadcasting the status changed event
Changed the log level for an error and bump plugin version